### PR TITLE
Update README files to reflect the new directory structure.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ The frontends all have their own examples. Checkout the [Python frontend][py].
 Check out the [Code of Conduct][cc] and the [Contributing Guidelines][contrib].
 
 [cc]: CODE_OF_CONDUCT.md
-[core]: src/core/
-[py]: src/python/
+[core]: puddle-core/
+[py]: puddle-python/
 [contrib]: CONTRIBUTING.md
 [lfs]: https://git-lfs.github.com/
 [project page]: http://misl.cs.washington.edu/projects/puddle.html

--- a/puddle-python/README.md
+++ b/puddle-python/README.md
@@ -12,7 +12,7 @@ Once you have Python 3.6 and `pipenv`, do the following to setup the project:
 ```shell
 # clone and enter the repo
 git clone git@github.com:uwmisl/puddle.git
-cd puddle/src/python
+cd puddle-python
 
 # use pipenv to install requirements into a virtualenv
 # --dev gets the development dependencies too


### PR DESCRIPTION
[Minor] There were a few links in the README files that still reference the old directory structure (prior to dd7f100f211a5dd9e77248b2340301c553893c2b), resulting in 404s when you click them. I updated them to reflect the new structure. 